### PR TITLE
Logging requests and errors to file on client

### DIFF
--- a/crawlera-bench
+++ b/crawlera-bench
@@ -11,6 +11,12 @@ from requests.auth import HTTPProxyAuth
 logger = logging.getLogger('crawlera-bench')
 
 
+def setup_logger(file_path):
+    logging.getLogger('crawlera-bench').setLevel(level=logging.ERROR)
+    stream_handler = logging.FileHandler(file_path)
+    logger.addHandler(stream_handler)
+
+
 def parse_args():
     p = argparse.ArgumentParser(description="Crawlera benchmarking tool")
     p.add_argument("urlsfile", help="File with URLs to try")
@@ -31,6 +37,10 @@ def parse_args():
              "header is used instead of CONNECT",
         default=False,
         )
+    p.add_argument("--add-file-logger", type=setup_logger, nargs='?',
+                   help="Allows to store verbose requests/errors information "
+                   " in logfile",
+                   const="/tmp/benchmark_log")
     return p.parse_args()
 
 
@@ -58,6 +68,8 @@ def worker_request(
             headers["x-crawlera-use-https"] = 1
 
         try:
+            logger.info("Requesting: url:{}, headers: {}, cert: {}"
+                        .format(url, headers, certificate))
             r = requests.get(
                 url,
                 headers=headers,
@@ -68,14 +80,20 @@ def worker_request(
                 verify=certificate)
             if r.status_code == 503:
                 rk = 'r503'
+                logger.error("503 from url:{}, headers: {}, cert: {}"
+                             .format(url, headers, certificate))
             else:
                 rk = 'r%d' % (r.status_code / 100)
             with statslock:
                 stats[rk] += m
         except requests.Timeout:
             stats["t"] += m
+            logger.error("Timeout from url:{}, headers: {}, cert: {}"
+                         .format(url, headers, certificate))
         except Exception:
             stats["e"] += m
+            logger.error("{} from url:{}, headers: {}, cert: {}"
+                         .format(sys.exc_info(), url, headers, certificate))
         finally:
             wait = time.time() - t
             with statslock:
@@ -108,9 +126,6 @@ def dumpstats(allstats, statslock, args):
 def main():
     start_time = time.time()
     args = parse_args()
-    logging.basicConfig()
-    logging.getLogger('requests').setLevel(logging.ERROR)
-
     allstats = defaultdict(lambda: defaultdict(int))
     statslock = Lock()
     queue = Queue(maxsize=1)

--- a/crawlera-bench
+++ b/crawlera-bench
@@ -12,7 +12,7 @@ logger = logging.getLogger('crawlera-bench')
 logger.setLevel(level=logging.ERROR)
 
 
-def add_file_handler(file_path):
+def log_to_file(file_path):
     stream_handler = logging.FileHandler(file_path)
     logger.addHandler(stream_handler)
 
@@ -41,7 +41,7 @@ def parse_args():
              "header is used instead of CONNECT",
         default=False,
         )
-    p.add_argument("--add-file-handler", type=add_file_handler, nargs='?',
+    p.add_argument("--log-to-file", type=log_to_file, nargs='?',
                    help="Allows to store verbose requests/errors information "
                    " in logfile",
                    const="/tmp/benchmark_log")

--- a/crawlera-bench
+++ b/crawlera-bench
@@ -9,12 +9,16 @@ from Queue import Queue
 from requests.auth import HTTPProxyAuth
 
 logger = logging.getLogger('crawlera-bench')
+logger.setLevel(level=logging.ERROR)
 
 
-def setup_logger(file_path):
-    logging.getLogger('crawlera-bench').setLevel(level=logging.ERROR)
+def add_file_handler(file_path):
     stream_handler = logging.FileHandler(file_path)
     logger.addHandler(stream_handler)
+
+
+def set_log_level(level):
+    logger.setLevel(level=level)
 
 
 def parse_args():
@@ -37,10 +41,14 @@ def parse_args():
              "header is used instead of CONNECT",
         default=False,
         )
-    p.add_argument("--add-file-logger", type=setup_logger, nargs='?',
+    p.add_argument("--add-file-handler", type=add_file_handler, nargs='?',
                    help="Allows to store verbose requests/errors information "
                    " in logfile",
                    const="/tmp/benchmark_log")
+    p.add_argument("--log-level", type=set_log_level, nargs='?',
+                   help="Set log level (use INFO to add more information)",
+                   const="ERROR")
+
     return p.parse_args()
 
 
@@ -66,10 +74,7 @@ def worker_request(
         if not certificate and url.startswith("https"):
             url = url.replace("https://", "http://", 1)
             headers["x-crawlera-use-https"] = 1
-
         try:
-            logger.info("Requesting: url:{}, headers: {}, cert: {}"
-                        .format(url, headers, certificate))
             r = requests.get(
                 url,
                 headers=headers,
@@ -80,20 +85,22 @@ def worker_request(
                 verify=certificate)
             if r.status_code == 503:
                 rk = 'r503'
-                logger.error("503 from url:{}, headers: {}, cert: {}"
-                             .format(url, headers, certificate))
+                logger.error("503 from url:{}, headers: {}"
+                             .format(url, headers))
             else:
                 rk = 'r%d' % (r.status_code / 100)
+                logger.info("{}: url:{}, headers:{}"
+                            .format(r.status_code, url, headers))
             with statslock:
                 stats[rk] += m
         except requests.Timeout:
             stats["t"] += m
-            logger.error("Timeout from url:{}, headers: {}, cert: {}"
-                         .format(url, headers, certificate))
+            logger.error("Timeout from url:{}, headers: {}"
+                         .format(url, headers))
         except Exception:
             stats["e"] += m
-            logger.error("{} from url:{}, headers: {}, cert: {}"
-                         .format(sys.exc_info(), url, headers, certificate))
+            logger.error("{} from url:{}, headers: {}"
+                         .format(sys.exc_info(), url, headers))
         finally:
             wait = time.time() - t
             with statslock:


### PR DESCRIPTION
Added functionality which allows to log requests/error codes on client side
(useful when requests are not visible on masters)